### PR TITLE
Fix some options don't apply (Android) (#263)

### DIFF
--- a/flutter_vlc_player/CHANGELOG.md
+++ b/flutter_vlc_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.5
+* Fix issue with options applying (Android)
+* Update VLCKit for iOS and Android
+Credits to Vladislav Murashko (https://github.com/mrvancor).
+
 ## 6.0.4
 * Added VLC http options
 Credits to Alireza Setayesh (https://github.com/alr2413).
@@ -46,7 +51,7 @@ Credits to Alireza Setayesh (https://github.com/alr2413), Mitch Ross (https://gi
 Credits to Alireza Setayesh (https://github.com/alr2413), Mitch Ross (https://github.com/mitchross) and Yurii Prykhodko (https://github.com/solid-yuriiprykhodko).
 
 ## 4.0.3
-* Update VLCKit for iOS and iOS. Cleanup example Pod file. Clean up example gradle. 
+* Update VLCKit for iOS and Android. Cleanup example Pod file. Clean up example gradle. 
 * Removed dispose calls on VlcPlayerController from VlcPlayer.
 * Fix argument-less functions throwing FlutterMethodNotImplemented.
 Credits to Mitch Ross (https://github.com/mitchross).

--- a/flutter_vlc_player/android/build.gradle
+++ b/flutter_vlc_player/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'org.videolan.android:libvlc-all:3.3.14'
+    implementation 'org.videolan.android:libvlc-all:3.4.3'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.annotation:annotation:1.2.0'

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
@@ -50,6 +50,7 @@ final class FlutterVlcPlayer implements PlatformView {
     //
     private LibVLC libVLC;
     private MediaPlayer mediaPlayer;
+    private List<String> options;
     private List<RendererDiscoverer> rendererDiscoverers = new ArrayList<>();
     private List<RendererItem> rendererItems = new ArrayList<>();
     private boolean isDisposed = false;
@@ -125,6 +126,7 @@ final class FlutterVlcPlayer implements PlatformView {
     // }
 
     public void initialize(List<String> options) {
+        this.options = options; 
         libVLC = new LibVLC(context, options);
         mediaPlayer = new MediaPlayer(libVLC);
         setupVlcMediaPlayer();
@@ -352,6 +354,9 @@ final class FlutterVlcPlayer implements PlatformView {
             if (hwAccValue == HwAcc.DECODING) {
                 media.addOption(":no-mediacodec-dr");
                 media.addOption(":no-omxil-dr");
+            }
+            if(options != null) {
+                options.forEach(option -> media.addOption(option));
             }
             mediaPlayer.setMedia(media);
             media.release();

--- a/flutter_vlc_player/ios/flutter_vlc_player.podspec
+++ b/flutter_vlc_player/ios/flutter_vlc_player.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
-  s.dependency 'MobileVLCKit', '~> 3.3.15'
+  s.dependency 'MobileVLCKit', '~> 3.3.17'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.

--- a/flutter_vlc_player/pubspec.yaml
+++ b/flutter_vlc_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_vlc_player
 description: A VLC-powered alternative to Flutter's video_player. Supports multiple players on one screen.
-version: 6.0.4
+version: 6.0.5
 homepage: https://github.com/solid-software/flutter_vlc_player/
 
 environment:


### PR DESCRIPTION
* Changes:
- Fix some options don't apply (Android)
- Update libvlc to 3.4.3 (Android)

Fixes solid-software/flutter_vlc_player#126

* Update MobileVLCKit to 3.3.17

* Changes:
- Increment version
- Update changelog

* Add null check for options